### PR TITLE
[EVOL] SDK initialization as part of the plugin[EVOL] Manage platform specific SDKs versions internally 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.2
+
+- Support SDK initialization as part of the plugin
+- Manage platform specific SDKs versions internally
+
 ## 0.0.1
 
 - Initial version

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Several commands are available in Screeb flutter plugin api :
 ### InitSdk command
 
 ```dart
-PluginScreeb.initSdk("channelId");
+PluginScreeb.initSdk("<android-channel-id", "<ios-channel-id");
 ```
 
 ### SetIdentity command

--- a/README.md
+++ b/README.md
@@ -12,7 +12,20 @@ A flutter plugin to integrate Screeb mobile sdk for Android and/or iOS.
 
 ## Getting Started
 
-Screeb sdk needs to be installed and initialized on each platform before being used in flutter.
+You should set IOS target build configuration `BUILD_LIBRARY_FOR_DISTRIBUTION` to `YES` in your `Podfile` to avoid runtime crash:
+```
+post_install do |installer|
+  ...
+  installer.pods_project.targets.each do |target|
+    ...
+
+    target.build_configurations.each do |config|
+      ...
+      config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
+    end
+  end
+end
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ post_install do |installer|
 end
 ```
 
+### Android specific configuration
+
+The Android sdk needs to be notified of activities lifecycle changes to be correctly started.
+
+It is mandatory to pass the Application context to the plugin in your custom Application class
+in the `onCreate` function :
+
+```kotlin
+    override fun onCreate() {
+    super.onCreate()
+    PluginScreebPlugin.setAppContext(this)
+}
+```
+
 ## Usage
 
 Several commands are available in Screeb flutter plugin api :

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A flutter plugin to integrate Screeb mobile sdk for Android and/or iOS.
 ## Getting Started
 
 You should set IOS target build configuration `BUILD_LIBRARY_FOR_DISTRIBUTION` to `YES` in your `Podfile` to avoid runtime crash:
-```
+```ruby
 post_install do |installer|
   ...
   installer.pods_project.targets.each do |target|

--- a/README.md
+++ b/README.md
@@ -14,52 +14,15 @@ A flutter plugin to integrate Screeb mobile sdk for Android and/or iOS.
 
 Screeb sdk needs to be installed and initialized on each platform before being used in flutter.
 
-### Android
-
-Installation with MavenCentral : 
-
-```groovy
-implementation 'app.screeb.sdk:android-sdk:1.1.0'
-```
-
-Initialization in your custom Application class
-
-```kotlin
-// simple initialization
-val screeb = Screeb.Builder()
-        .withContext(this)
-        .withChannelId("<website-id>")
-        .build()
-
-// detailed initialization using a unique id and custom properties, see Identify visitors section
-val screeb = Screeb.Builder()
-        .withContext(this)
-        .withChannelId("<website-id>")
-        .withVisitorId("johndoe@screeb.app") // optional
-        .withVisitorProperties(VisitorProperties().apply {
-            this["email"] = "johndoe@screeb.app"
-            this["age"] = 32
-        }) // optional
-        .build()
-```
-
-### iOS
-
-Installation instruction in the project's Podfile
-
-```ruby
-pod "Screeb", "0.7.0"
-```
-
-Initialization in your AppDelegate.swift file :
-
-```swift
-Screeb.initSdk(context: controller, channelId: "<website-id>")
-```
-
-## Usage in flutter
+## Usage
 
 Several commands are available in Screeb flutter plugin api :
+
+### InitSdk command
+
+```dart
+PluginScreeb.initSdk("channelId");
+```
 
 ### SetIdentity command
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,4 +48,5 @@ android {
 dependencies {
     implementation "app.screeb.sdk:android-sdk:1.1.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'app.screeb.sdk:android-sdk:1.1.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'app.screeb.plugin_screeb'
 version '1.0.0'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.0'
     repositories {
         google()
         mavenCentral()
@@ -46,7 +46,7 @@ android {
 }
 
 dependencies {
-    implementation "app.screeb.sdk:android-sdk:1.1.0"
+    implementation "app.screeb.sdk:android-sdk:1.2.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'app.screeb.sdk:android-sdk:1.1.0'
 }

--- a/android/src/main/kotlin/app/screeb/plugin_screeb/PluginScreebPlugin.kt
+++ b/android/src/main/kotlin/app/screeb/plugin_screeb/PluginScreebPlugin.kt
@@ -1,5 +1,6 @@
 package app.screeb.plugin_screeb
 
+import android.content.Context
 import androidx.annotation.NonNull
 import app.screeb.sdk.Screeb
 
@@ -26,10 +27,11 @@ class PluginScreebPlugin : FlutterPlugin, MethodCallHandler {
 
         if (call.method == CALL_INIT_SDK) {
             val channelId = arguments[0] as String
-            screeb = Screeb.Builder()
-                    .withContext(context)
-                    .withChannelId(channelId)
-                    .build()
+            if (screeb == null) {
+                result.success(false)
+                return
+            }
+            screeb?.pluginInit(channelId, null, null)
             result.success(true)
             return
         }
@@ -81,6 +83,13 @@ class PluginScreebPlugin : FlutterPlugin, MethodCallHandler {
         const val CALL_SEND_TRACKING_EVENT = "sendTrackingEvent"
         const val CALL_SEND_TRACKING_SCREEN = "sendTrackingScreen"
         const val CALL_VISITOR_PROPERTY = "visitorProperty"
+
+        fun setAppContext(context: Context){
+            screeb = Screeb.Builder()
+                .withContext(context)
+                .withPluginMode(true)
+                .build()
+        }
     }
 }
 

--- a/android/src/main/kotlin/app/screeb/plugin_screeb/PluginScreebPlugin.kt
+++ b/android/src/main/kotlin/app/screeb/plugin_screeb/PluginScreebPlugin.kt
@@ -20,12 +20,22 @@ class PluginScreebPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+        val arguments = call.arguments as ArrayList<*>
+        if (call.method == CALL_INIT_SDK) {
+            val channelId = arguments[0] as String
+            screeb = Screeb.Builder()
+                    .withContext(this)
+                    .withChannelId(channelId)
+                    .build();
+            result.success(true)
+            return
+        }
+
         if (screeb == null) {
             result.error(ERROR_SCREEB_NOT_INIT, null, null)
             return
         }
 
-        val arguments = call.arguments as ArrayList<*>
         when (call.method) {
             CALL_SET_IDENTITY -> {
                 val userId = arguments[0] as String
@@ -63,6 +73,7 @@ class PluginScreebPlugin : FlutterPlugin, MethodCallHandler {
         var screeb: Screeb? = null
         const val ERROR_SCREEB_NOT_INIT = "ERROR_SCREEB_NOT_INIT"
 
+        const val CALL_INIT_SDK = "initSdk"
         const val CALL_SET_IDENTITY = "setIdentity"
         const val CALL_SEND_TRACKING_EVENT = "sendTrackingEvent"
         const val CALL_SEND_TRACKING_SCREEN = "sendTrackingScreen"

--- a/android/src/main/kotlin/app/screeb/plugin_screeb/PluginScreebPlugin.kt
+++ b/android/src/main/kotlin/app/screeb/plugin_screeb/PluginScreebPlugin.kt
@@ -13,20 +13,23 @@ import java.util.HashMap
 /** PluginScreebPlugin */
 class PluginScreebPlugin : FlutterPlugin, MethodCallHandler {
     private lateinit var channel: MethodChannel
+    private lateinit var context: android.content.Context
 
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "plugin_screeb")
         channel.setMethodCallHandler(this)
+        context = flutterPluginBinding.applicationContext
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
         val arguments = call.arguments as ArrayList<*>
+
         if (call.method == CALL_INIT_SDK) {
             val channelId = arguments[0] as String
             screeb = Screeb.Builder()
-                    .withContext(this)
+                    .withContext(context)
                     .withChannelId(channelId)
-                    .build();
+                    .build()
             result.success(true)
             return
         }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -68,6 +68,5 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'app.screeb.sdk:android-sdk:1.1.0'
     implementation "androidx.multidex:multidex:$multidex_version"
 }

--- a/example/android/app/src/main/kotlin/app/screeb/plugin_screeb_example/ExampleApplication.kt
+++ b/example/android/app/src/main/kotlin/app/screeb/plugin_screeb_example/ExampleApplication.kt
@@ -3,11 +3,13 @@ package app.screeb.plugin_screeb_example
 import android.app.Application
 import android.content.Context
 import androidx.multidex.MultiDex
+import app.screeb.plugin_screeb.PluginScreebPlugin
 import java.util.*
 
 class ExampleApplication: Application() {
     override fun onCreate() {
         super.onCreate()
+        PluginScreebPlugin.setAppContext(this)
     }
 
     override fun attachBaseContext(base: Context) {

--- a/example/android/app/src/main/kotlin/app/screeb/plugin_screeb_example/ExampleApplication.kt
+++ b/example/android/app/src/main/kotlin/app/screeb/plugin_screeb_example/ExampleApplication.kt
@@ -11,17 +11,6 @@ import java.util.*
 class ExampleApplication: Application() {
     override fun onCreate() {
         super.onCreate()
-        screeb = Screeb.Builder()
-            .withContext(this)
-            .withChannelId("082b7590-1621-4f72-8030-731a98cd1448") // Preview survey
-            .withVisitorId("clement2@screeb.app")
-            .withVisitorProperties(VisitorProperties().apply {
-                this["email"] = "flutter_plugin@screeb.app"
-                this["age"] = 32
-                this["company"] = "Flutter"
-                this["logged_at"] = Date()
-            })
-            .build()
     }
 
     override fun attachBaseContext(base: Context) {

--- a/example/android/app/src/main/kotlin/app/screeb/plugin_screeb_example/ExampleApplication.kt
+++ b/example/android/app/src/main/kotlin/app/screeb/plugin_screeb_example/ExampleApplication.kt
@@ -3,9 +3,6 @@ package app.screeb.plugin_screeb_example
 import android.app.Application
 import android.content.Context
 import androidx.multidex.MultiDex
-import app.screeb.plugin_screeb.PluginScreebPlugin.Companion.screeb
-import app.screeb.sdk.Screeb
-import app.screeb.sdk.init.model.VisitorProperties
 import java.util.*
 
 class ExampleApplication: Application() {

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -31,7 +31,6 @@ target 'Runner' do
   use_frameworks!
   use_modular_headers!
 
-  pod "Screeb", "0.7.0"
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -6,8 +6,8 @@ PODS:
   - Kingfisher (7.1.2)
   - plugin_screeb (0.0.1):
     - Flutter
-    - Screeb (~> 0.7)
-  - Screeb (0.7.0):
+    - Screeb (~> 0.8)
+  - Screeb (0.8.0):
     - Alamofire (~> 5.4)
     - AlamofireNetworkActivityLogger (~> 3.4)
     - Kingfisher (~> 7.0)
@@ -17,7 +17,6 @@ PODS:
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - plugin_screeb (from `.symlinks/plugins/plugin_screeb/ios`)
-  - Screeb (= 0.7.0)
 
 SPEC REPOS:
   trunk:
@@ -38,10 +37,10 @@ SPEC CHECKSUMS:
   AlamofireNetworkActivityLogger: 162ab8aee00e6267a4304d7cc134e13ccfe3bcc5
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   Kingfisher: 44ed6a8504763f27bab46163adfac83f5deb240c
-  plugin_screeb: 0fd332d21360baf0884aca488fef6133472bbe2a
-  Screeb: 950f362c945ea515f55289a3f990d17b54183a45
+  plugin_screeb: 52910306a67ffa557853139cfbc43299f935d8aa
+  Screeb: d9e06e6402cfb4cd8272b7ecb1565f2ac14ec114
   Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
 
-PODFILE CHECKSUM: 7a003bec55e85f8d691d87d0fd2b0133e9801abc
+PODFILE CHECKSUM: 3a514d0c8286cdf222654062887b78155e90bfda
 
 COCOAPODS: 1.11.2

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -9,8 +9,6 @@ import Screeb
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
-    let controller = self.window?.rootViewController
-    Screeb.initSdk(context: controller, channelId: "5c62c145-91f1-4abd-8aa2-63d7847db1e1")
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,6 +1,5 @@
 import UIKit
 import Flutter
-import Screeb
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,6 +17,14 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+
+    PluginScreeb.initSdk("082b7590-1621-4f72-8030-731a98cd1448");
+    // Optionally setup the identity of the visitor
+    _visitorProperty(<String, dynamic>{
+      "email": "flutter_plugin@screeb.app",
+      "age": 32,
+      "company": "Flutter",
+    });
   }
 
   void _setIdentity(String userId){

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,7 +18,7 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
 
-    PluginScreeb.initSdk("082b7590-1621-4f72-8030-731a98cd1448");
+    PluginScreeb.initSdk("082b7590-1621-4f72-8030-731a98cd1448", "5c62c145-91f1-4abd-8aa2-63d7847db1e1");
     // Optionally setup the identity of the visitor
     _visitorProperty(<String, dynamic>{
       "email": "flutter_plugin@screeb.app",

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -108,7 +108,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/ios/Classes/SwiftPluginScreebPlugin.swift
+++ b/ios/Classes/SwiftPluginScreebPlugin.swift
@@ -62,10 +62,10 @@ public class SwiftPluginScreebPlugin: NSObject, FlutterPlugin {
                                     message: "iOS could not extract flutter arguments in method: \(call.method)",
                                     details: nil))
             }
-            default:
-                result(FlutterError(code: "-1", message: "iOS could not extract " +
-                       "flutter arguments in method: \(call.method)", details: nil))
-                break
+        default:
+            result(FlutterError(code: "-1", message: "iOS could not extract " +
+                "flutter arguments in method: \(call.method)", details: nil))
+            break
         }
   }
 

--- a/ios/Classes/SwiftPluginScreebPlugin.swift
+++ b/ios/Classes/SwiftPluginScreebPlugin.swift
@@ -10,9 +10,18 @@ public class SwiftPluginScreebPlugin: NSObject, FlutterPlugin {
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    print("ios command \(call.method)")
     guard let args = call.arguments as? [Any] else { return }
     switch call.method {
+        case "initSdk":
+            if let channelId = args[0] as? String {
+                let controller = self.window?.rootViewController
+                Screeb.initSdk(context: controller, channelId: channelId)
+                result(true)
+            } else {
+                result(FlutterError(code: "-1",
+                                    message: "iOS could not extract flutter arguments in method: \(call.method)",
+                                    details: nil))
+            }
         case "setIdentity":
             if let userId = args[0] as? String {
                 Screeb.setIdentity(uniqueVisitorId: userId)

--- a/ios/Classes/SwiftPluginScreebPlugin.swift
+++ b/ios/Classes/SwiftPluginScreebPlugin.swift
@@ -14,9 +14,12 @@ public class SwiftPluginScreebPlugin: NSObject, FlutterPlugin {
     switch call.method {
         case "initSdk":
             if let channelId = args[0] as? String {
-                let controller = self.window?.rootViewController
-                Screeb.initSdk(context: controller, channelId: channelId)
-                result(true)
+                if let controller = UIApplication.shared.keyWindow?.rootViewController as? UIViewController {
+                    Screeb.initSdk(context: controller, channelId: channelId)
+                    result(true)
+                } else {
+                    result(false)
+                }
             } else {
                 result(FlutterError(code: "-1",
                                     message: "iOS could not extract flutter arguments in method: \(call.method)",

--- a/ios/plugin_screeb.podspec
+++ b/ios/plugin_screeb.podspec
@@ -21,7 +21,7 @@ Screeb plugin for Flutter, simplify use of Screeb in Flutter apps
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
 
-  s.dependency 'Screeb', '~> 0.7'
+  s.dependency 'Screeb', '~> 0.8'
   s.preserve_paths = 'Screeb.xcframework'
     s.xcconfig = { 'OTHER_LDFLAGS' => '-framework Screeb' }
     s.vendored_frameworks = 'Screeb.xcframework'

--- a/lib/plugin_screeb.dart
+++ b/lib/plugin_screeb.dart
@@ -5,6 +5,16 @@ import 'package:flutter/services.dart';
 class PluginScreeb {
   static const MethodChannel _channel = MethodChannel('plugin_screeb');
 
+  /// Provides a way to initialize the SDK with a specific channel ID
+  ///
+  /// Call this method first elsewhere subsequent calls will fail
+  /// Providing a [channelId] is mandatory, please visit your account to find
+  /// the identifier
+  static Future<bool?> initSdk(String channelId) async {
+    final bool? success = await _channel.invokeMethod('initSdk', [channelId]);
+    return success;
+  }
+
   /// Provides an authentified id for the user of the app
   ///
   /// Providing a [userId] is important to sharpen the Screeb targeting engine

--- a/lib/plugin_screeb.dart
+++ b/lib/plugin_screeb.dart
@@ -11,7 +11,7 @@ class PluginScreeb {
   ///
   /// Call this method first elsewhere subsequent calls will fail
   /// Providing a [androidChannelId] and [iosChannelId] is mandatory, please visit your account to find
-  /// the identifier
+  /// the identifiers
   static Future<bool?> initSdk(
       String androidChannelId, String iosChannelId) async {
     if (Platform.isIOS) {

--- a/lib/plugin_screeb.dart
+++ b/lib/plugin_screeb.dart
@@ -1,18 +1,24 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 
 class PluginScreeb {
   static const MethodChannel _channel = MethodChannel('plugin_screeb');
 
-  /// Provides a way to initialize the SDK with a specific channel ID
+  /// Provides a way to initialize the SDK with a specific channel ID by
+  /// platform Android and iOS
   ///
   /// Call this method first elsewhere subsequent calls will fail
-  /// Providing a [channelId] is mandatory, please visit your account to find
+  /// Providing a [androidChannelId] and [iosChannelId] is mandatory, please visit your account to find
   /// the identifier
-  static Future<bool?> initSdk(String channelId) async {
-    final bool? success = await _channel.invokeMethod('initSdk', [channelId]);
-    return success;
+  static Future<bool?> initSdk(
+      String androidChannelId, String iosChannelId) async {
+    if (Platform.isIOS) {
+      return await _channel.invokeMethod('initSdk', [iosChannelId]);
+    } else if (Platform.isAndroid) {
+      return await _channel.invokeMethod('initSdk', [androidChannelId]);
+    }
   }
 
   /// Provides an authentified id for the user of the app

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: plugin_screeb
 description: A flutter plugin to integrate Screeb mobile sdk for Android and/or iOS.
-version: 0.0.1
+version: 0.0.2
 homepage: https://screeb.app
 repository: https://github.com/ScreebApp/flutter-screeb-plugin
 


### PR DESCRIPTION
This pull request contains:
- Support SDK initialization as part of the plugin: It allows easier integration for the client as no platform specific code is required. Also the instance member `screeb` from the Kotlin code was quite hard/impossible to setup from java code. (Our project was created using Java)
- Manage platform specific SDKs versions internally: It allows the developers of the plugin to manage Screeb SDK versionning internally. Thus you can publish a new release with platform related changes required to make the updated SDK still working for both Android / IOS
- Add instructions about the `BUILD_LIBRARY_FOR_DISTRIBUTION` required changes to avoid runtime crashes.

README.MD and Changelog has been updated accordingly.