### PR TITLE
add namespace for AGP 8.0+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
+    namespace 'app.screeb.plugin_screeb'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Hi! 
I've added the namespace necessary for compiling when a project uses android AGP 8.0+